### PR TITLE
feat: Create reusable SearchBar component

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -54,6 +54,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="marketplace"
+        options={{
+          title: 'Pazaryeri',
+          tabBarIcon: ({ color }) => <TabBarIcon name="shopping-bag" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/marketplace.js
+++ b/app/(tabs)/marketplace.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import SearchBar from '../../components/SearchBar';
+
+const MarketplaceScreen = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList
+        ListHeaderComponent={
+          <>
+            <Text className="text-2xl font-bold text-secondary">Pazaryeri</Text>
+            <SearchBar placeholder="Model ara..." />
+          </>
+        }
+        data={[]}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={({ item }) => <Text>{item}</Text>}
+      />
+    </View>
+  );
+};
+
+export default MarketplaceScreen;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,10 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ["babel-preset-expo"],
-    plugins: ["nativewind/babel"],
+    presets: [
+      ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+      "nativewind/babel",
+    ],
+    plugins: ["react-native-reanimated/plugin"],
   };
 };

--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -1,0 +1,20 @@
+import { View, TextInput, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { COLORS } from '../constants/theme';
+
+const SearchBar = ({ placeholder }) => {
+  return (
+    <View className="flex-row items-center bg-white rounded-xl shadow p-3 my-4">
+      <Feather name="search" size={20} color={COLORS.gray} className="mr-2" />
+      <TextInput
+        placeholder={placeholder}
+        className="flex-1 text-base text-secondary"
+      />
+      <TouchableOpacity>
+        <Feather name="sliders" size={20} color={COLORS.secondary} />
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default SearchBar;


### PR DESCRIPTION
This commit introduces a new reusable `SearchBar` component.

The component includes:
- A text input for search queries.
- A search icon from `@expo/vector-icons`.
- A filter icon.

The new `SearchBar` has been integrated into a new "Pazaryeri" (Marketplace) screen, which is now accessible via a new tab in the main navigation.

The Babel configuration was updated to correctly support NativeWind styling.