### PR TITLE
Fix(marketplace): Correct image URLs and babel config

### DIFF
--- a/app/(tabs)/marketplace.tsx
+++ b/app/(tabs)/marketplace.tsx
@@ -11,7 +11,7 @@ const mockListings = [
     series: 'HW Art Cars',
     price: '$2.50',
     seller: 'hotwheels_fan',
-    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/c/c2/Bone_Shaker_2022_HW_Art_Cars.jpg/revision/latest/scale-to-width-down/350?cb=20211110222',
+    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/c/c2/Bone_Shaker_2022_HW_Art_Cars.jpg',
   },
   {
     id: '2',
@@ -19,7 +19,7 @@ const mockListings = [
     series: 'HW Dream Garage',
     price: '$3.00',
     seller: 'collector22',
-    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/8/8a/Twin_Mill_HCT39.jpg/revision/latest/scale-to-width-down/350?cb=20220102002',
+    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/8/8a/Twin_Mill_HCT39.jpg',
   },
   {
     id: '3',
@@ -27,7 +27,7 @@ const mockListings = [
     series: "HW Surf's Up",
     price: '$2.00',
     seller: 'beach_racer',
-    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/a/a2/Deora_II_-_2021.jpg/revision/latest/scale-to-width-down/350?cb=20210313010',
+    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/a/a2/Deora_II_-_2021.jpg',
   },
   {
     id: '4',
@@ -35,7 +35,7 @@ const mockListings = [
     series: 'Muscle Mania',
     price: '$4.50',
     seller: 'classic_cars',
-    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/e/e5/%2767_Camaro_grn.JPG/revision/latest/scale-to-width-down/350?cb=20081203013',
+    imageUrl: 'https://static.wikia.nocookie.net/hotwheels/images/e/e5/%2767_Camaro_grn.JPG',
   },
 ];
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,10 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ["babel-preset-expo"],
-    plugins: [
+    presets: [
+      ["babel-preset-expo", { jsxImportSource: "nativewind" }],
       "nativewind/babel",
-      "react-native-reanimated/plugin"
     ],
+    plugins: ["react-native-reanimated/plugin"],
   };
 };


### PR DESCRIPTION
This commit addresses two issues:

1.  **Marketplace Image Rendering:** The `marketplace.tsx` component was using malformed image URLs from `static.wikia.nocookie.net` that included revision and scaling parameters. These parameters were causing images to fail to load. The URLs have been cleaned to point directly to the `.jpg` or `.JPG` files, resolving the rendering issue.

2.  **Expo Go Crash (Error Code 500):** The application was crashing in the Expo Go app due to a misconfiguration in `babel.config.js`. The `nativewind/babel` preset was not correctly integrated with `babel-preset-expo`. The configuration has been updated to follow the correct setup for NativeWind, which resolves the crash.